### PR TITLE
LOG: Small fix

### DIFF
--- a/happi/device.py
+++ b/happi/device.py
@@ -284,7 +284,7 @@ class Device(six.with_metaclass(InfoMeta, object)):
 
         #Handle additional information
         if kwargs:
-            logging.info('Additional information for %s was defined %s',
+            logger.debug('Additional information for %s was defined %s',
                          self.name, ', '.join(kwargs.keys()))
             self.extraneous = kwargs
 


### PR DESCRIPTION
Switch info to debug, use module logger instead of root logger.
Largely a selfish PR, this log message spams me while loading devices in skywalker.