### PR TITLE
ENH: Device loading

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--- Provide a general summary of the issue in the Title above -->
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment you experienced the bug in -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--- Provide a general summary of your changes in the Title above -->
+## Description
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, and the tests you ran to -->
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Where Has This Been Documented?
+<!--  Include where the changes made have been documented. -->
+<!--  This can simply be  a comment in the code or updating a docstring -->
+
+<!--
+## Screenshots (if appropriate):
+-->

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - conda update -q conda conda-build
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION simplejson coverage pip pymongo numpy pytest six -c conda-forge 
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION simplejson coverage pip pymongo pytest six -c conda-forge 
   - source activate test-environment
   - pip install -r requirements.txt
   - pip install -r test-requirements.txt

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -14,11 +14,11 @@ requirements:
 
     run:
       - six
-      - numpy
+      - jinja2
       - prettytable
+      - simplejson
       - pymongo 
       - python
-      - simplejson
 test:
     imports:
       - happi

--- a/happi/client.py
+++ b/happi/client.py
@@ -2,6 +2,7 @@
 # Standard #
 ############
 import sys
+import math
 import logging
 import inspect
 import time as ttime
@@ -10,7 +11,6 @@ import time as ttime
 # Third Party #
 ###############
 import six
-import numpy as np #Could be removed if necessary
 
 ##########
 # Module #
@@ -322,7 +322,7 @@ class Client(object):
         if start or end:
 
             if not end:
-                end = np.inf
+                end = math.inf
 
             if start >= end:
                 raise ValueError("Invalid beamline range")

--- a/happi/device.py
+++ b/happi/device.py
@@ -94,7 +94,7 @@ class EntryInfo(object):
         -------
         value :
             Identical to the provided value except it may have been converted
-            to the correc type
+            to the correct type
 
         Raises
         ------

--- a/happi/device.py
+++ b/happi/device.py
@@ -1,23 +1,24 @@
-from __future__ import print_function
-
-###################
-# Standard Packages
-###################
+############
+# Standard #
+############
 import re
 import six
 import sys
 import logging
 
 from collections import OrderedDict
-from prettytable import PrettyTable 
+from prettytable import PrettyTable
 
-###################
-# Module Packages
-###################
+###############
+# Third Party #
+###############
+
+##########
+# Module #
+##########
 from .errors import ContainerError
 
 logger = logging.getLogger(__name__)
-
 
 
 class EntryInfo(object):
@@ -63,50 +64,65 @@ class EntryInfo(object):
             number   = EntryInfo('Device number', enforce=int, default=0)
     """
     def __init__(self, doc=None, optional=True, enforce=None, default=None):
-        self.key      = None #Set later by parent class
-        self.doc      = doc
-        self.enforce  = enforce
+        self.key = None  # Set later by parent class
+        self.doc = doc
+        self.enforce = enforce
         self.optional = optional
 
-        #Explicitly set default to None b/c this is how we ensure mandatory
-        #information was set
+        # Explicitly set default to None b/c this is how we ensure mandatory
+        # information was set
         if optional:
-            self.default  = default
-
+            self.default = default
         else:
             self.default = None
 
-        #Check that default value is correct type
+        # Check that default value is correct type
         try:
             self.enforce_value(default)
-
         except ValueError:
             raise ContainerError('Default value must match the enforced type')
 
-
     def enforce_value(self, value):
-        if not self.enforce or value == None:
+        """
+        Enforce the rules of the EntryInfo
+
+        Parameters
+        ----------
+        value
+
+        Returns
+        -------
+        value :
+            Identical to the provided value except it may have been converted
+            to the correc type
+
+        Raises
+        ------
+        ValueError:
+            If the value is not the correct type, or does not match the pattern
+        """
+        if not self.enforce or value is None:
             return value
 
         elif isinstance(self.enforce, type):
-            #Try and convert to type, otherwise raise ValueError
+            # Try and convert to type, otherwise raise ValueError
             return self.enforce(value)
 
-        elif isinstance(self.enforce, (list,tuple,set)):
-            #Check that value is in list, otherwise raise ValueError
+        elif isinstance(self.enforce, (list, tuple, set)):
+            # Check that value is in list, otherwise raise ValueError
             if value not in self.enforce:
                 raise ValueError('{} was not found in the enforce list {}'
                                  ''.format(self.key, self.enforce))
             return value
 
         elif isinstance(self.enforce, re._pattern_type):
-            #Try and match regex patttern, otherwise raise ValueError
+            # Try and match regex patttern, otherwise raise ValueError
             if not self.enforce.match(value):
                 raise ValueError('{} did not match the enforced pattern {}'
-                                ''.format(self.key, self.enforce.pattern))
+                                 ''.format(self.key, self.enforce.pattern))
             return value
 
-        #Invalid enforcement
+        # Invalid enforcement
         else:
             raise ContainerError('EntryInfo {} has an invalid enforce'
                                  ''.format(self.key))
@@ -118,12 +134,11 @@ class EntryInfo(object):
         doc = ['{} attribute'.format(self.__class__.__name__),
                '::',
                '',
-              ]
+               ]
 
         doc.append(repr(self))
         doc.append('')
         return '\n'.join(doc)
-
 
     def __get__(self, instance, owner):
 
@@ -132,11 +147,9 @@ class EntryInfo(object):
 
         return instance.__dict__[self.key]
 
-
     def __set__(self, instance, value):
 
         instance.__dict__[self.key] = self.enforce_value(value)
-
 
     def __repr__(self):
 
@@ -151,20 +164,19 @@ class EntryInfo(object):
 
 class InfoMeta(type):
 
-
     def __new__(cls, name, bases, clsdict):
         clsobj = super(InfoMeta, cls).__new__(cls, name, bases, clsdict)
 
-        #These attributes are used by device so can not be overwritten
-        RESERVED_ATTRS = ['info_names','entry_info',
-                          'mandatory_info','_info_attrs',
+        # These attributes are used by device so can not be overwritten
+        RESERVED_ATTRS = ['info_names', 'entry_info',
+                          'mandatory_info', '_info_attrs',
                           'post', 'save', 'creation', '_id',
                           'last_edit']
 
-        #Create dict to hold information
+        # Create dict to hold information
         clsobj._info_attrs = OrderedDict()
 
-        #Handle multiple inheritance
+        # Handle multiple inheritance
         for base in reversed(bases):
 
             if not hasattr(base, '_info_attrs'):
@@ -173,7 +185,7 @@ class InfoMeta(type):
             for attr, info in base._info_attrs.items():
                 clsobj._info_attrs[attr] = info
 
-        #Load from highest classEntry
+        # Load from highest classEntry
         for attr, value in clsdict.items():
             if isinstance(value, EntryInfo):
                 if attr in RESERVED_ATTRS:
@@ -184,15 +196,13 @@ class InfoMeta(type):
 
                 clsobj._info_attrs[attr] = value
 
-        #Notify Info of key names
+        # Notify Info of key names
         for attr, info in clsobj._info_attrs.items():
             info.key = attr
-
-        #Create docstring information
+        # Create docstring information
         for info in clsobj._info_attrs.values():
             info.__doc__ = info.make_docstring(clsobj)
-
-        #Store Entry Information
+        # Store Entry Information
         clsobj.entry_info = list(clsobj._info_attrs.values())
 
         return clsobj
@@ -237,60 +247,55 @@ class Device(six.with_metaclass(InfoMeta, object)):
     -------
     .. code ::
 
-        d = Device(name = 'my_device',      #Alias name for device
+        d = Device(name = 'my_device',         #Alias name for device
                    prefix  = 'CXI:DG2:DEV:01', #Base PV for device
-                   note  = 'Example',        #Piece of arbitrary metadata
+                   note  = 'Example',          #Piece of arbitrary metadata
                   )
     """
-
-    #Entry Info
-    name           = EntryInfo('Shorthand name for the device',
-                                optional=False, enforce=str)
-    prefix            = EntryInfo('A base PV for all related records',
-                                optional=False, enforce=str)
-    beamline        = EntryInfo('Section of beamline the device belongs',
-                                optional=False, enforce=str)
-    z               = EntryInfo('Beamline position of the device',
-                                enforce=float, default = -1.0)
-    stand           = EntryInfo('Acronym for stand, must be three alphanumeric '
-                                'characters',
-                                enforce=re.compile(r'[A-Z0-9]{3}$'))
-    main_screen     = EntryInfo('The absolute path to the main control screen',
-                                enforce=str)
-    embedded_screen = EntryInfo('The absolute path to an embeddable screen',
-                                enforce=str)
-    active          = EntryInfo('Whether the device is actively deployed',
-                                 enforce=bool, default=True)
-    system          = EntryInfo('The system the device is involved with, i.e '
-                                'Vacuum, Timing e.t.c',
-                                enforce=str)
-    macros          = EntryInfo("The EDM macro string asscociated with the "
-                                "with the device. By using a jinja2 template, "
-                                "this can reference other EntryInfo keywords.",
-                                enforce=str)
-    parent          = EntryInfo('If the device is a component of another, '
-                                'enter the name',
-                                enforce=str)
+    name = EntryInfo('Shorthand name for the device',
+                     optional=False, enforce=str)
+    prefix = EntryInfo('A base PV for all related records',
+                       optional=False, enforce=str)
+    beamline = EntryInfo('Section of beamline the device belongs',
+                         optional=False, enforce=str)
+    z = EntryInfo('Beamline position of the device',
+                  enforce=float, default=-1.0)
+    device_class = EntryInfo("Python class that represents the Device",
+                             enforce=str)
+    args = EntryInfo("Arguments to pass to device_class",
+                     enforce=list, default=['{{prefix}}'])
+    kwargs = EntryInfo("Keyword arguments to pass to device_class",
+                       enforce=dict, default={'name': '{{name}}'})
+    stand = EntryInfo('Acronym for stand, must be three alphanumeric '
+                      'characters', enforce=re.compile(r'[A-Z0-9]{3}$'))
+    screen = EntryInfo('The absolute path to the main control screen',
+                       enforce=str)
+    active = EntryInfo('Whether the device is actively deployed',
+                       enforce=bool, default=True)
+    system = EntryInfo('The system the device is involved with, i.e '
+                       'Vacuum, Timing e.t.c',
+                       enforce=str)
+    macros = EntryInfo("The EDM macro string asscociated with the "
+                       "with the device. By using a jinja2 template, "
+                       "this can reference other EntryInfo keywords.",
+                       enforce=str)
+    parent = EntryInfo('If the device is a component of another, '
+                       'enter the name', enforce=str)
 
     def __init__(self, **kwargs):
-        #Load given information into device class
+        # Load given information into device class
         for info in self.entry_info:
             if info.key in kwargs.keys():
                 setattr(self, info.key, kwargs.pop(info.key))
-
             else:
                 setattr(self, info.key, info.default)
-
-
-        #Handle additional information
+        # Handle additional information
         if kwargs:
             logger.debug('Additional information for %s was defined %s',
                          self.name, ', '.join(kwargs.keys()))
             self.extraneous = kwargs
-
         else:
             self.extraneous = {}
-
 
     @property
     def info_names(self):
@@ -299,14 +304,12 @@ class Device(six.with_metaclass(InfoMeta, object)):
         """
         return [info.key for info in self.entry_info]
 
-
     @property
     def mandatory_info(self):
         """
         Mandatory information for the device to be initialized
         """
         return [info.key for info in self.entry_info if not info.optional]
-
 
     def show_info(self, handle=sys.stdout):
         """
@@ -320,11 +323,12 @@ class Device(six.with_metaclass(InfoMeta, object)):
         pt = PrettyTable(['EntryInfo', 'Value'])
         pt.align = 'r'
         pt.align['EntryInfo'] = 'l'
-        pt.align['Value']     = 'l'
+        pt.align['Value'] = 'l'
         pt.float_format = '8.5'
 
+        # Gather all device information, do not show private
+        # information that begins with an underscore
         show_info = self.post()
-
         public_keys = sorted([key for key in show_info.keys()
                               if not key.startswith('_')])
         for key in public_keys:
@@ -332,26 +336,23 @@ class Device(six.with_metaclass(InfoMeta, object)):
 
         print(pt, file=handle)
 
-
     def post(self):
         """
-        Create a document to be loaded into the MongoDB
+        Create a document to be loaded into the happi database
 
         Returns
         -------
         post : dict
             Dictionary of all contained information
         """
-        #Grab all the specified information
-        post = dict([(key, getattr(self,key)) for key in self.info_names])
+        # Grab all the specified information
+        post = dict([(key, getattr(self, key)) for key in self.info_names])
 
-
-        #Add additional metadata
+        # Add additional metadata
         if self.extraneous:
             post.update(self.extraneous)
 
         return post
-
 
     def save(self):
         """
@@ -359,13 +360,11 @@ class Device(six.with_metaclass(InfoMeta, object)):
         """
         raise NotImplementedError
 
-
     def __repr__(self):
         return '{} {} (prefix={}, z={})'.format(self.__class__.__name__,
-                                              self.name,
-                                              self.prefix,
-                                              self.z)
-
+                                                self.name,
+                                                self.prefix,
+                                                self.z)
 
     def __eq__(self, other):
         return (self.prefix, self.name) == (other.prefix, other.name)

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -1,0 +1,99 @@
+"""
+Functions to instantiate the Python representations of happi Containers
+"""
+############
+# Standard #
+############
+import sys
+import logging
+import importlib
+
+###############
+# Third Party #
+###############
+from jinja2 import Environment, meta
+
+
+##########
+# Module #
+##########
+
+logger = logging.getLogger(__name__)
+
+
+def fill_template(template, device, enforce_type=False):
+    """
+    Fill a Jinja2 template using information from a device
+
+    Parameters
+    ----------
+    template : str
+        Jinja2 template
+
+    device : happi.Device
+        Any device container
+
+    enforce_type : bool, optional
+        Force the output of the rendered template to match the enforced type of
+        the happi information that was used to fill it.
+    """
+    # Create a template and render our happi information inside it
+    env = Environment().from_string(template)
+    filled = env.render(**device.post())
+    if enforce_type:
+        # Find which variable we used in the template, get the type and convert
+        # our rendered template to agree with this
+        info = meta.find_undeclared_variables(env.environment.parse(template))
+        enforce = type(getattr(device, info.pop()))
+        filled = enforce(filled)
+    return filled
+
+
+def from_container(device):
+    """
+    Load a device from a happi container
+
+    The container is queried for the device_class, args and kwargs. Then if the
+    associated package is not already loaded it is imported. The specified
+    class is then instantiated with the given args and kwargs provided.
+
+    Parameters
+    ----------
+    device : happi.Device
+
+    Returns
+    -------
+    obj : happi.Device.device_class
+    """
+    # Find the class and module of the container.
+    if not device.device_class:
+        raise ValueError("Device %s does not have an associated Python class",
+                         device.name)
+    mod, cls = device.device_class.rsplit('.', 1)
+    # Import the module if not already present
+    # Otherwise use the stashed version in sys.modules
+    if mod in sys.modules:
+        logger.debug("Using previously imported version of %s", mod)
+        mod = sys.modules[mod]
+    else:
+        logger.info("Importing %s", mod)
+        mod = importlib.import_module(mod)
+    # Gather our device class from the given module
+    try:
+        cls = getattr(mod, cls)
+    except AttributeError as exc:
+        raise ImportError("Unable to import %s from %s" %
+                          (cls, mod.__name__)) from exc
+
+    # Create correctly typed arguments from happi information
+    def create_arg(arg):
+        if not isinstance(arg, str):
+            return arg
+        return fill_template(arg, device, enforce_type=True)
+
+    # Treat all our args and kwargs as templates
+    args = [create_arg(arg) for arg in device.args]
+    kwargs = dict((key, create_arg(val))
+                  for key, val in device.kwargs.items())
+    # Return the instantiated device
+    return cls(*args, **kwargs)

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -11,7 +11,12 @@
 # Module #
 ##########
 from happi import Device, EntryInfo
-from happi.loader import fill_template, from_container
+from happi.loader import fill_template, from_container, load_devices
+from happi.utils import create_alias
+
+
+class TimeDevice(Device):
+    days = EntryInfo("Number of days", enforce=int)
 
 
 def test_fill_template(device):
@@ -25,8 +30,6 @@ def test_fill_template(device):
 
 
 def test_from_container():
-    class TimeDevice(Device):
-        days = EntryInfo("Number of days", enforce=int)
     # Create a datetime device
     d = TimeDevice(name='Test', prefix='Tst:This', beamline='TST',
                    device_class='datetime.timedelta', args=list(), days=10,
@@ -35,3 +38,26 @@ def test_from_container():
     # Now import datetime and check that we constructed ours correctly
     import datetime
     assert td == datetime.timedelta(days=10, seconds=30)
+
+
+def test_load_devices():
+    # Create a bunch of devices to load
+    devs = [TimeDevice(name='Test 1', prefix='Tst1:This', beamline='TST',
+                       device_class='datetime.timedelta', args=list(), days=10,
+                       kwargs={'days': '{{days}}', 'seconds': 30}),
+            TimeDevice(name='Test 2', prefix='Tst2:This', beamline='TST',
+                       device_class='datetime.timedelta', args=list(), days=10,
+                       kwargs={'days': '{{days}}', 'seconds': 30}),
+            TimeDevice(name='Test 3', prefix='Tst3:This', beamline='TST',
+                       device_class='datetime.timedelta', args=list(), days=10,
+                       kwargs={'days': '{{days}}', 'seconds': 30}),
+            Device(name='Bad', prefix='Not:Here', beamline='BAD',
+                   device_class='non.existant')]
+    # Load our devices
+    space = load_devices(*devs, pprint=True)
+    # Check all our devices are there
+    assert all([create_alias(dev.name) in space.__dict__ for dev in devs])
+    # Devices were loading properly or exceptions were stored
+    import datetime
+    assert space.test_1 == datetime.timedelta(days=10, seconds=30)
+    assert isinstance(space.bad, ImportError)

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -1,0 +1,37 @@
+############
+# Standard #
+############
+
+###############
+# Third Party #
+###############
+
+
+##########
+# Module #
+##########
+from happi import Device, EntryInfo
+from happi.loader import fill_template, from_container
+
+
+def test_fill_template(device):
+    # Check that we can properly render a template
+    template = "{{name}}"
+    assert device.name == fill_template(template, device)
+    # Check that we can enforce a type
+    template = '{{z}}'
+    z = fill_template(template, device, enforce_type=True)
+    assert isinstance(z, float)
+
+
+def test_from_container():
+    class TimeDevice(Device):
+        days = EntryInfo("Number of days", enforce=int)
+    # Create a datetime device
+    d = TimeDevice(name='Test', prefix='Tst:This', beamline='TST',
+                   device_class='datetime.timedelta', args=list(), days=10,
+                   kwargs={'days': '{{days}}', 'seconds': 30})
+    td = from_container(d)
+    # Now import datetime and check that we constructed ours correctly
+    import datetime
+    assert td == datetime.timedelta(days=10, seconds=30)

--- a/happi/utils.py
+++ b/happi/utils.py
@@ -1,0 +1,22 @@
+"""
+Basic module utilities
+"""
+############
+# Standard #
+############
+
+###############
+# Third Party #
+###############
+
+
+##########
+# Module #
+##########
+
+
+def create_alias(name):
+    """
+    Clean an alias to be an acceptable Python variable
+    """
+    return name.replace(' ', '_').replace('.', '_').lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+jinja2
 simplejson
 pymongo
-numpy
 prettytable
 six


### PR DESCRIPTION
## Description

### #20
Devices now have the following standard pieces of EntryInfo: `device_class`, `args` and `kwargs`. This divorces us from the model of a one to one mapping of `happi.Containers` to `pcdsdevices`. It also allows the addition of initialization arguments without adding EntryInfo or changing classes. By default, the `args` and `kwargs` default to the standard `ophyd.Device` (prefix, name=name) loading scheme.

### #21
Because we don't want to duplicate information in the `args` and `kwargs` that is contained in other EntryInfo. I added a function that will render `jinja2` templates with a devices specific attributes. That means for instance the defaults args are will be `"{{prefix}}"`

The awkward thing about this setup is you still want to enforce a non-string type. We need to render the template, then reconvert it using the `EntryInfo.enforce`. For instance, if your kwargs looked like:
```python
kwargs = {'z': '{{z}}'}
```
The `fill_template` command would sub-in the z value, but then would be swapped back to a float later. It is unclear how to properly implement this in the case where there are multiple attributes in a template that disagree on type. I'm open to discussing an alternative to `jinja2` templates but I want to avoid inventing our own language for doing this.

### #22
There are now two functions to support device loading

#### `from_container`
Looks at `device_class` imports the module, fills any `jinja2` templates with device information and loads the device. Exceptions **are not** caught during this function

#### `load_devices`
Load a series of devices, catching all exceptions and making sure that one bad apple will not ruin the barrel. Right now they are captured in a common `NameSpace`. The function has a `pprint` option that has a nice print out of what devices loaded and which did not. 

<img width="311" alt="screen shot 2017-11-27 at 10 28 22 am" src="https://user-images.githubusercontent.com/25753048/33282577-e4e51600-d35d-11e7-83e4-f0b3b99c1966.png">

The only controversial portion is if a device raises an exception, I store that under the device name. The nice thing is you can then in the same IPython terminal examine the traceback without needing to check logs e.t.c. You also don't keep slamming tab for a device you think should be there. We can decide if this is a wanted feature.


### #19 
Cleaned up PEP8 errors using `flake8` in files I touched. This will be an ongoing effort

## Motivation
Closes #20
Closes #21 
Closes #22

## Documentation
Docstrings are written. I want to do an overhaul of the `happi` docs. So the new functons will be included as part of #23 

## Tests
New tests added for generic device loading and jinja2 templating