### PR TITLE
Container Fix

### DIFF
--- a/happi/containers.py
+++ b/happi/containers.py
@@ -147,7 +147,7 @@ class IPM(Diagnostic):
     prefix = copy(Diagnostic.prefix)
     prefix.enforce = re.compile(r'.*IPM.*')
     device_class = copy(Device.device_class)
-    device_class.default = 'pcdsdevics.device_types.IPM'
+    device_class.default = 'pcdsdevices.device_types.IPM'
 
 
 class Attenuator(BeamControl):

--- a/happi/containers.py
+++ b/happi/containers.py
@@ -2,7 +2,7 @@
 Define subclasses of Device for specific hardware.
 """
 import re
-from copy import copy
+from copy import copy, deepcopy
 from .device import Device, EntryInfo
 
 
@@ -112,7 +112,7 @@ class PIM(Diagnostic):
     prefix_det = EntryInfo("Prefix for associated camera", enforce=str)
     device_class = copy(Device.device_class)
     device_class.default = 'pcdsdevices.device_types.PIM'
-    kwargs = copy(Device.kwargs)
+    kwargs = deepcopy(Device.kwargs)
     kwargs.default['prefix_det'] = "{{prefix_det}}"
 
 
@@ -174,7 +174,7 @@ class Attenuator(BeamControl):
     device_class.default = 'pcdsdevices.device_types.Attenuator'
     n_filters = EntryInfo("Number of filters on the Attenuator",
                           enforce=int, optional=False)
-    kwargs = copy(Device.kwargs)
+    kwargs = deepcopy(Device.kwargs)
     kwargs.default['n_filters'] = "{{n_filters}}"
 
 
@@ -270,7 +270,7 @@ class LODCM(BeamSteering):
     device_class.default = 'pcdsdevices.device_types.LODCM'
     mono_line = EntryInfo("Name of the MONO beamline",
                           enforce=str, optional=False)
-    kwargs = copy(Device.kwargs)
+    kwargs = deepcopy(Device.kwargs)
     kwargs.default.update({'mono_line': '{{mono_line}}',
                            'main_line': '{{beamline}}'})
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* When you only copy the `kwargs` EntryInfo the `kwargs.default` dictionary still points to the original dictionary. For the other EntryInfo you don't notice because you make a new pointer when you set.
```python
system = copy(Device.system)
system.default = 'vacuum'
```
However, when you call `.update` or `__setitem__` this is not the case. Now all the kwargs copies are deepcopies.

* The IPM `device_class` was mis-spelled.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on mfx config