### PR TITLE
Exception Details

### DIFF
--- a/happi/client.py
+++ b/happi/client.py
@@ -189,11 +189,11 @@ class Client:
         logger.debug("Instantiating device based on found information ...")
         try:
             device = self.create_device(doc['type'], **doc)
-        except (KeyError, TypeError):
+        except (KeyError, TypeError) as exc:
             raise EntryError('The information relating to the device class '
                              'has been modified to the point where the object '
                              'can not be initialized, please load the '
-                             'corresponding document')
+                             'corresponding document') from exc
 
         # Add the save method to the device
         device.save = lambda: self._store(device, insert=False)

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -39,8 +39,13 @@ def fill_template(template, device, enforce_type=False):
         # We select a type at random here. If we use two different variables
         # in the same template that disagree on type we could have an issue
         # but I decided that we will deal with that issue if it arises
-        enforce = type(getattr(device, info.pop()))
-        filled = enforce(filled)
+        try:
+            info_name = info.pop()
+            enforce = type(getattr(device, info_name))
+            filled = enforce(filled)
+        except AttributeError as exc:
+            logger.warning("Unable to enforce the type of %s, because it is "
+                           "a piece of extraneous information")
     return filled
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
1. Was having trouble deciphering an exception in the happi Client. Added the `raise . from .` syntax to give a more descriptive traceback. I figured this should just go in the library permanently.
2. While writing tests for another module, I discovered that you can not use `load_devices` if one of your classes references metadata on load. This is because we try and enforce the type by looking up the EntryInfo, but there is no EntryInfo for metadata. This just wraps it in a try / except block and trusts that the given metadata is already the correct type.
