### PR TITLE
Attach metadata

### DIFF
--- a/happi/loader.py
+++ b/happi/loader.py
@@ -49,7 +49,7 @@ def fill_template(template, device, enforce_type=False):
     return filled
 
 
-def from_container(device):
+def from_container(device, attach_md=True):
     """
     Load a device from a happi container
 
@@ -59,11 +59,18 @@ def from_container(device):
 
     This function does not attempt to catch exceptions either during module
     imports or device creation. If you would like a series of independent
-    devices to be loaded use :func:`.load_devices`
+    devices to be loaded use :func:`.load_devices`.
+
+    By default, the instantiated object has the original container added on as
+    ``.md``. This allows applications to utilize additional metadata
+    information that may not be included in the basic class constructor.
 
     Parameters
     ----------
     device : happi.Device
+
+    attach_md: bool, optional
+        Attach the container to the instantiated object as `md`
 
     Returns
     -------
@@ -100,7 +107,14 @@ def from_container(device):
     kwargs = dict((key, create_arg(val))
                   for key, val in device.kwargs.items())
     # Return the instantiated device
-    return cls(*args, **kwargs)
+    obj = cls(*args, **kwargs)
+    # Attach the metadata to the object
+    if attach_md:
+        try:
+            setattr(obj, 'md', device)
+        except Exception as exc:
+            logger.warning("Unable to attach metadata dictionary to device")
+    return obj
 
 
 def load_devices(*devices, pprint=False, namespace=None):

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -28,6 +28,15 @@ def test_from_container():
     assert td == datetime.timedelta(days=10, seconds=30)
 
 
+def test_add_md():
+    d = Device(name='Test', prefix='Tst:This',
+               beamline="TST", args = list(),
+               device_class="happi.Device")
+    obj = from_container(d, attach_md=True)
+    assert obj.md.beamline == 'TST'
+    assert obj.md.name == 'Test'
+
+
 def test_load_devices():
     # Create a bunch of devices to load
     devs = [TimeDevice(name='Test 1', prefix='Tst1:This', beamline='TST',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Attach metadata to objects after they are created by happi. This is wrapped in a `try / except` block  as some classes do not support `setattr` for new attributes. You can also choose not do attach the metadata at all with the `attach_md` kwarg.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows applications like `hutch_python` and `lightpath` to access metadata of the devices that may not be included in the class constructor i.e `my_device.md.z`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added an additional test to check metadata addition

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Update doc-string
