### PR TITLE
Questionnaire Kwargs

### DIFF
--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -53,7 +53,7 @@ class QSBackend(JSONBackend):
             beamline = prop_ids[proposal]['Instrument']
         # Invalid proposal id for this run
         except KeyError as exc:
-            raise DatabaseError('Unable to find proposal %s'.format(proposal))\
+            raise DatabaseError('Unable to find proposal {}'.format(proposal))\
                   from exc
         # Find if our exception gave an HTTP status code and interpret it
         except Exception as exc:
@@ -63,7 +63,7 @@ class QSBackend(JSONBackend):
                 status_code = ''
             # No information found from run
             if status_code == 500:
-                reason = 'No run id found %s found %s'.format(run_no)
+                reason = 'No run id found for {}'.format(run_no)
             # Invalid credentials
             elif status_code == 401:
                 reason = 'Invalid credentials'

--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -38,12 +38,11 @@ class QSBackend(JSONBackend):
     proposal: str
         Proposal identifier i.e "LR32"
     """
-    ws_url = 'https://pswww.slac.stanford.edu/ws-kerb/questionnaire'
     device_translations = {'motors': 'pcdsdevices.epics_motor.EpicsMotor'}
 
-    def __init__(self, run_no, proposal):
+    def __init__(self, run_no, proposal, **kwargs):
         # Create our client and gather the raw information from the client
-        self.qs = QuestionnaireClient(self.ws_url)
+        self.qs = QuestionnaireClient(**kwargs)
 
         # Ensure that our user entered a valid run number and proposal
         # identification

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -87,7 +87,7 @@ def from_container(device, attach_md=True):
         logger.debug("Using previously imported version of %s", mod)
         mod = sys.modules[mod]
     else:
-        logger.info("Importing %s", mod)
+        logger.debug("Importing %s", mod)
         mod = importlib.import_module(mod)
     # Gather our device class from the given module
     try:
@@ -146,7 +146,7 @@ def load_devices(*devices, pprint=False, namespace=None):
                   end=' ')
         try:
             loaded = from_container(device)
-            logger.info("Succesfully %s [%s] loaded!",
+            logger.info("Loading %s [%s] ... \033[32mSUCCESS\033[0m!",
                         device.name, device.device_class)
             if pprint:
                 print("\033[32mSUCCESS\033[0m")

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -143,7 +143,8 @@ def mockqsbackend():
 
     with patch('happi.backends.qs_db.QuestionnaireClient') as qs_cli:
         # Replace QuestionnaireClient with our test version
-        mock_qs = MockQuestionnaireClient()
+        mock_qs = MockQuestionnaireClient(use_kerberos=False,
+                                          user='user', pw='pw')
         qs_cli.return_value = mock_qs
         # Instantiate a fake device
         backend = QSBackend(15, 'LR32')

--- a/happi/tests/conftest.py
+++ b/happi/tests/conftest.py
@@ -143,7 +143,7 @@ def mockqsbackend():
 
     with patch('happi.backends.qs_db.QuestionnaireClient') as qs_cli:
         # Replace QuestionnaireClient with our test version
-        mock_qs = MockQuestionnaireClient(QSBackend.ws_url, use_kerberos=False)
+        mock_qs = MockQuestionnaireClient()
         qs_cli.return_value = mock_qs
         # Instantiate a fake device
         backend = QSBackend(15, 'LR32')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* `QSBackend` passes kwargs to the QuestionnaireClient to allow multiple authentication methods
* Logging messages have been updated to match the MFX `dev` area changes

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
* Allow the use of `ws-auth` after https://github.com/slaclab/psdm_qs_cli/pull/2