### PR TITLE
ENH: Cache

### DIFF
--- a/happi/__init__.py
+++ b/happi/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from .device import Device, EntryInfo  # noqa
 from .client import Client  # noqa
-
+from .loader import load_devices, cache  # noqa
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -134,7 +134,7 @@ def from_container(device, attach_md=True, use_cache=True):
     return obj
 
 
-def load_devices(*devices, pprint=False, namespace=None):
+def load_devices(*devices, pprint=False, namespace=None, **kwargs):
     """
     Load a series of devices into a namespace
 
@@ -149,6 +149,9 @@ def load_devices(*devices, pprint=False, namespace=None):
     namespace : obj, optional
         Namespace to collect loaded devices in. By default this will be a
         ``types.SimpleNamespace``
+
+    kwargs:
+        Are passed to :func:`.from_container`
     """
     # Create our namespace if we were not given one
     namespace = namespace or types.SimpleNamespace()
@@ -162,7 +165,7 @@ def load_devices(*devices, pprint=False, namespace=None):
                                               device.device_class),
                   end=' ')
         try:
-            loaded = from_container(device)
+            loaded = from_container(device, **kwargs)
             logger.info("Loading %s [%s] ... \033[32mSUCCESS\033[0m!",
                         device.name, device.device_class)
             if pprint:

--- a/happi/loader.py
+++ b/happi/loader.py
@@ -12,6 +12,8 @@ from .utils import create_alias
 
 logger = logging.getLogger(__name__)
 
+cache= dict()
+
 
 def fill_template(template, device, enforce_type=False):
     """
@@ -49,7 +51,7 @@ def fill_template(template, device, enforce_type=False):
     return filled
 
 
-def from_container(device, attach_md=True):
+def from_container(device, attach_md=True, use_cache=True):
     """
     Load a device from a happi container
 
@@ -72,10 +74,22 @@ def from_container(device, attach_md=True):
     attach_md: bool, optional
         Attach the container to the instantiated object as `md`
 
+    use_cache: bool, optional
+        When devices are loaded they are stored in the ``happi.cache``
+        dictionary. This means that repeated attempts to load the device will
+        return the same object. This prevents unnecessary EPICS connections
+        from being initialized in the same process. If a new object is
+        needed, set `use_cache` to False and a new object will be created,
+        overriding the current cached object
+
     Returns
     -------
     obj : happi.Device.device_class
     """
+    # Return a cached version of the device if present and not forced
+    if use_cache and device.prefix in cache:
+        return cache[device.prefix]
+
     # Find the class and module of the container.
     if not device.device_class:
         raise ValueError("Device %s does not have an associated Python class",
@@ -114,6 +128,9 @@ def from_container(device, attach_md=True):
             setattr(obj, 'md', device)
         except Exception as exc:
             logger.warning("Unable to attach metadata dictionary to device")
+
+    # Store a copy of the device in the cache
+    cache[device.prefix] = obj
     return obj
 
 

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -1,4 +1,4 @@
-from happi import Device, EntryInfo
+from happi import Device, EntryInfo, cache
 from happi.loader import fill_template, from_container, load_devices
 from happi.utils import create_alias
 
@@ -19,7 +19,7 @@ def test_fill_template(device):
 
 def test_from_container():
     # Create a datetime device
-    d = TimeDevice(name='Test', prefix='Tst:This', beamline='TST',
+    d = TimeDevice(name='Test', prefix='Tst:This:1', beamline='TST',
                    device_class='datetime.timedelta', args=list(), days=10,
                    kwargs={'days': '{{days}}', 'seconds': 30})
     td = from_container(d)
@@ -28,8 +28,19 @@ def test_from_container():
     assert td == datetime.timedelta(days=10, seconds=30)
 
 
+def test_caching():
+    # Create a datetime device
+    d = TimeDevice(name='Test', prefix='Tst:This:2', beamline='TST',
+                   device_class='datetime.timedelta', args=list(), days=10,
+                   kwargs={'days': '{{days}}', 'seconds': 30})
+    td = from_container(d)
+    assert d.prefix in cache
+    assert id(td) == id(from_container(d))
+    assert id(td) != id(from_container(d, use_cache=False))
+
+
 def test_add_md():
-    d = Device(name='Test', prefix='Tst:This',
+    d = Device(name='Test', prefix='Tst:This:3',
                beamline="TST", args=list(),
                device_class="happi.Device")
     obj = from_container(d, attach_md=True)

--- a/happi/tests/test_loader.py
+++ b/happi/tests/test_loader.py
@@ -30,7 +30,7 @@ def test_from_container():
 
 def test_add_md():
     d = Device(name='Test', prefix='Tst:This',
-               beamline="TST", args = list(),
+               beamline="TST", args=list(),
                device_class="happi.Device")
     obj = from_container(d, attach_md=True)
     assert obj.md.beamline == 'TST'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Simplest implementation of device caching. Idea is to check if a device has already been created rather than creating a new one. Cache is available as `happi.cache`. If a user wants to force a new object to be created they can pass `use_cache=False` into `from_container`. This creates a new device and replaces it in the cache.

### Implementation Detail
* This is currently just a regular dictionary. We can make it a `weakref` if we want to destroy devices when they go out of scope.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #29 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added a test where we compare  object memory addresses using  `id` 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
 Added a docstring in `from_container`.

