### PR TITLE
FIX: Do not load devices without names or prefixes

### DIFF
--- a/happi/backends/qs_db.py
+++ b/happi/backends/qs_db.py
@@ -99,7 +99,7 @@ class QSBackend(JSONBackend):
             else:
                 logger.debug("Found %s devices under %s table",
                              len(devices), field)
-                for dev_info in devices.values():
+                for num, dev_info in devices.items():
                     try:
                         post = {'name': dev_info.pop('name'),
                                 'prefix': dev_info['pvbase'],
@@ -113,9 +113,16 @@ class QSBackend(JSONBackend):
                                 '_id': dev_info.pop('pvbase')}
                         # Add extraneous metadata
                         post.update(dev_info)
-                    except KeyError as exc:
-                        logger.warning("Can not define a device without %s",
-                                       exc)
+                        # Check that the we haven't received empty strings from
+                        # the Questionnaire
+                        for key in ['prefix', 'name']:
+                            if not post.get(key):
+                                raise Exception("Unable to create a device "
+                                                " without %s".format(key))
+                    except Exception as exc:
+                        logger.warning("Unable to create a %s from "
+                                       "Questionnaire row %s",
+                                       _class, num)
                     else:
                         self.db[post['_id']] = post
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Prior to this devices with empty names and prefixes were loaded by the Questionnaire plugin. The code simply checked for the key, not that the key was an empty string. Now we:

* Check that both `name` and `prefix` are not empty strings
* Provide a much more descriptive warning message about which row in the table is bad.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #44 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on live Questionnaire with bad entries.
